### PR TITLE
DOC: Clarify that using sos as output type for iirdesign can have performance costs

### DIFF
--- a/scipy/signal/filter_design.py
+++ b/scipy/signal/filter_design.py
@@ -2112,8 +2112,11 @@ def iirdesign(wp, ws, gpass, gstop, analog=False, ftype='ellip', output='ba',
 
     output : {'ba', 'zpk', 'sos'}, optional
         Type of output:  numerator/denominator ('ba'), pole-zero ('zpk'), or
-        second-order sections ('sos'). Default is 'ba' for backwards
-        compatibility, but 'sos' should be used for general-purpose filtering.
+        second-order sections ('sos'). Default is 'ba' for backwards compatibility. 
+        In general 'sos' is recommended because inferring the 'ba' coëfficients 
+        suffers from numerical instabilities. Using the 'sos' filter is sometimes 
+        associated with additional computational costs, for data-intense use cases 
+        it is therefore recommended to also investigate the 'ba'-filter format.
     fs : float, optional
         The sampling frequency of the digital system.
 


### PR DESCRIPTION
#### Reference issue
Closes #12970: 
Documentation presents second order sections as the correct choice where there is an engineering decision to be made

#### What does this implement/fix?
It clarifies in the documentation string of iirdesign that although 'sos'-filters are generally recommended as the correct choice of filter form there are sometimes computational costs involved during filter application. 

#### Additional information
Issue #12970 provide code for reproducing a simple computational costs measurement. Also output for two example configurations is provided there.